### PR TITLE
Update code to handle dispatching events only to their related action

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ def handle_will_appear(event):
     print("Will Appear event received:", event)
 ```
 
+!!!INFO Handlers for action-specific events are dispatched only if the event is triggered by the associated action, ensuring isolation and predictability. For other types of events that are not associated with a specific action, handlers are dispatched without such restrictions.
+
+
 
 ### Writing Logs
 

--- a/streamdeck/manager.py
+++ b/streamdeck/manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from streamdeck.actions import ActionRegistry
 from streamdeck.command_sender import StreamDeckCommandSender
@@ -82,6 +82,9 @@ class PluginManager:
                 data: EventBase = event_adapter.validate_json(message)
                 logger.debug("Event received: %s", data.event)
 
-                for handler in self._registry.get_action_handlers(data.event): # type: ignore
+                # If the event is action-specific, we'll pass the action's uuid to the handler to ensure only the correct action is triggered.
+                event_action_uuid: str | None = cast(str, data.action) if data.is_action_specific() else None
+
+                for handler in self._registry.get_action_handlers(event_name=data.event, event_action_uuid=event_action_uuid):
                     # TODO: from contextual event occurences, save metadata to the action's properties.
                     handler(data)

--- a/streamdeck/models/events.py
+++ b/streamdeck/models/events.py
@@ -17,8 +17,9 @@ class EventBase(BaseModel, ABC):
     """Name of the event used to identify what occurred."""
 
     @classmethod
-    def is_action_specific(cls):
-        return "context" in cls.model_fields
+    def is_action_specific(cls) -> bool:
+        """Check if the event is specific to an action instance (i.e. the event has an "action" field)."""
+        return "action" in cls.model_fields
 
 
 class ApplicationDidLaunchEvent(EventBase):


### PR DESCRIPTION
Update to have events that were triggered by a specific action dispatch to only that action.

We do this for events that have the "action" field, which contains the triggering action's uuid, filtering out actions in the registry that don't have the same uuid value.

If an event doesn't have the "action" field, we continue to dispatch to all actions with handlers for the given event type.