### PR TITLE
Fix up StreamDeckCommandSender class and its GlobalSettings methods t…

### DIFF
--- a/streamdeck/command_sender.py
+++ b/streamdeck/command_sender.py
@@ -16,8 +16,9 @@ logger = getLogger("streamdeck.command_sender")
 
 class StreamDeckCommandSender:
     """Class for sending command event messages to the Stream Deck software through a WebSocket client."""
-    def __init__(self, client: WebSocketClient):
+    def __init__(self, client: WebSocketClient, plugin_registration_uuid: str):
         self._client = client
+        self._plugin_registration_uuid = plugin_registration_uuid
 
     def _send_event(self, event: str, **kwargs: Any) -> None:
         self._client.send_event({
@@ -38,18 +39,17 @@ class StreamDeckCommandSender:
             context=context,
         )
 
-    def set_global_settings(self, context: str, payload: dict[str, Any]) -> None:
+    def set_global_settings(self, payload: dict[str, Any]) -> None:
         self._send_event(
             event="setGlobalSettings",
-            context=context,
+            context=self._plugin_registration_uuid,
             payload=payload,
         )
 
-    def get_global_settings(self, context: str) -> None:
-        """FYI: It seems like this causes the 'didReceiveGlobalSettings' event to only the Property Inspector."""
+    def get_global_settings(self) -> None:
         self._send_event(
             event="getGlobalSettings",
-            context=context,
+            context=self._plugin_registration_uuid,
         )
 
     def open_url(self, context: str, url: str) -> None:

--- a/streamdeck/manager.py
+++ b/streamdeck/manager.py
@@ -95,7 +95,7 @@ class PluginManager:
         and triggers the appropriate action handlers based on the received events.
         """
         with WebSocketClient(port=self._port) as client:
-            command_sender = StreamDeckCommandSender(client)
+            command_sender = StreamDeckCommandSender(client, plugin_registration_uuid=self._registration_uuid)
 
             command_sender.send_action_registration(register_event=self._register_event, plugin_registration_uuid=self._registration_uuid)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import random
+import uuid
 
 import pytest
 
@@ -7,3 +8,8 @@ import pytest
 def port_number():
     """Fixture to provide a random 4-digit port number for each test."""
     return random.randint(1000, 9999)
+
+
+@pytest.fixture
+def plugin_registration_uuid() -> str:
+    return str(uuid.uuid1())

--- a/tests/plugin_manager/conftest.py
+++ b/tests/plugin_manager/conftest.py
@@ -9,14 +9,13 @@ from streamdeck.websocket import WebSocketClient
 
 
 @pytest.fixture
-def plugin_manager(port_number: int) -> PluginManager:
+def plugin_manager(port_number: int, plugin_registration_uuid: str) -> PluginManager:
     """Fixture that provides a configured instance of PluginManager for testing.
 
     Returns:
         PluginManager: An instance of PluginManager with test parameters.
     """
     plugin_uuid = "test-plugin-uuid"
-    plugin_registration_uuid = str(uuid.uuid1())
     register_event = "registerPlugin"
     info = {"some": "info"}
 


### PR DESCRIPTION
Stream Deck commands "setGlobalSettings" and "getGlobalSettings" should pass the value of the `registrationUUID` arg that the Stream Deck software passes in when starting up the plugin, rather than the action UUID from the event.