### PR TITLE
Refactor/generic event name field

### DIFF
--- a/streamdeck/actions.py
+++ b/streamdeck/actions.py
@@ -6,14 +6,13 @@ from functools import cached_property
 from logging import getLogger
 from typing import TYPE_CHECKING, cast
 
-from streamdeck.types import BaseEventHandlerFunc, LiteralStrGenericAlias
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
     from streamdeck.models.events import EventBase
-    from streamdeck.types import EventHandlerFunc, EventNameStr, TEvent_contra
+    from streamdeck.models.events.base import LiteralStrGenericAlias
+    from streamdeck.types import BaseEventHandlerFunc, EventHandlerFunc, EventNameStr, TEvent_contra
 
 
 logger = getLogger("streamdeck.actions")

--- a/streamdeck/actions.py
+++ b/streamdeck/actions.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from logging import getLogger
 from typing import TYPE_CHECKING, cast
 
-from streamdeck.types import BaseEventHandlerFunc
+from streamdeck.types import BaseEventHandlerFunc, LiteralStrGenericAlias
 
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ class ActionBase(ABC):
 
         return _wrapper
 
-    def get_event_handlers(self, event_name: EventNameStr, /) -> Generator[EventHandlerFunc[EventBase], None, None]:
+    def get_event_handlers(self, event_name: EventNameStr, /) -> Generator[EventHandlerFunc[EventBase[LiteralStrGenericAlias]], None, None]:
         """Get all event handlers for a specific event.
 
         Args:
@@ -112,7 +112,7 @@ class ActionRegistry:
         """
         self._plugin_actions.append(action)
 
-    def get_action_handlers(self, event_name: EventNameStr, event_action_uuid: str | None = None) -> Generator[EventHandlerFunc[EventBase], None, None]:
+    def get_action_handlers(self, event_name: EventNameStr, event_action_uuid: str | None = None) -> Generator[EventHandlerFunc[EventBase[LiteralStrGenericAlias]], None, None]:
         """Get all event handlers for a specific event from all registered actions.
 
         Args:

--- a/streamdeck/actions.py
+++ b/streamdeck/actions.py
@@ -42,10 +42,6 @@ class ActionBase(ABC):
         Raises:
             KeyError: If the provided event name is not available.
         """
-        # if event_name not in DEFAULT_EVENT_NAMES:
-        #     msg = f"Provided event name for action handler does not exist: {event_name}"
-        #     raise KeyError(msg)
-
         def _wrapper(func: EventHandlerFunc[TEvent_contra]) -> EventHandlerFunc[TEvent_contra]:
             # Cast to BaseEventHandlerFunc so that the storage type is consistent.
             self._events[event_name].add(cast("BaseEventHandlerFunc", func))
@@ -66,10 +62,6 @@ class ActionBase(ABC):
         Raises:
             KeyError: If the provided event name is not available.
         """
-        # if event_name not in DEFAULT_EVENT_NAMES:
-        #     msg = f"Provided event name for pulling handlers from action does not exist: {event_name}"
-        #     raise KeyError(msg)
-
         if event_name not in self._events:
             return
 

--- a/streamdeck/event_listener.py
+++ b/streamdeck/event_listener.py
@@ -6,6 +6,8 @@ from logging import getLogger
 from queue import Queue
 from typing import TYPE_CHECKING
 
+from streamdeck.types import LiteralStrGenericAlias
+
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -119,7 +121,7 @@ class EventListener(ABC):
     Event listeners are classes that listen for events and simply yield them as they come.
     The EventListenerManager will handle the threading and pushing the events yielded into a shared queue.
     """
-    event_models: ClassVar[list[type[EventBase]]]
+    event_models: ClassVar[list[type[EventBase[LiteralStrGenericAlias]]]]
     """A list of event models that the listener can yield. Read in by the PluginManager to model the incoming event data off of.
 
     The plugin-developer must define this list in their subclass.

--- a/streamdeck/event_listener.py
+++ b/streamdeck/event_listener.py
@@ -6,8 +6,6 @@ from logging import getLogger
 from queue import Queue
 from typing import TYPE_CHECKING
 
-from streamdeck.types import LiteralStrGenericAlias
-
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -16,6 +14,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeIs
 
     from streamdeck.models.events import EventBase
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 

--- a/streamdeck/manager.py
+++ b/streamdeck/manager.py
@@ -14,7 +14,6 @@ from streamdeck.models.events.common import ContextualEventMixin
 from streamdeck.types import (
     EventHandlerBasicFunc,
     EventHandlerFunc,
-    LiteralStrGenericAlias,
     TEvent_contra,
     is_bindable_handler,
 )
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from streamdeck.models.events import EventBase
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 # TODO: Fix this up to push to a log in the apropos directory and filename.

--- a/streamdeck/manager.py
+++ b/streamdeck/manager.py
@@ -14,6 +14,7 @@ from streamdeck.models.events.common import ContextualEventMixin
 from streamdeck.types import (
     EventHandlerBasicFunc,
     EventHandlerFunc,
+    LiteralStrGenericAlias,
     TEvent_contra,
     is_bindable_handler,
 )
@@ -120,7 +121,7 @@ class PluginManager:
 
         return handler
 
-    def _stream_event_data(self) -> Generator[EventBase, None, None]:
+    def _stream_event_data(self) -> Generator[EventBase[LiteralStrGenericAlias], None, None]:
         """Stream event data from the event listeners.
 
         Validate and model the incoming event data before yielding it.
@@ -130,7 +131,7 @@ class PluginManager:
         """
         for message in self._event_listener_manager.event_stream():
             try:
-                data: EventBase = self._event_adapter.validate_json(message)
+                data: EventBase[LiteralStrGenericAlias] = self._event_adapter.validate_json(message)
             except ValidationError:
                 logger.exception("Error modeling event data.")
                 continue

--- a/streamdeck/models/events/__init__.py
+++ b/streamdeck/models/events/__init__.py
@@ -31,8 +31,10 @@ from streamdeck.models.events.visibility import WillAppear, WillDisappear
 if TYPE_CHECKING:
     from typing import Final
 
+    from streamdeck.types import LiteralStrGenericAlias
 
-DEFAULT_EVENT_MODELS: Final[list[type[EventBase]]] = [
+
+DEFAULT_EVENT_MODELS: Final[list[type[EventBase[LiteralStrGenericAlias]]]] = [
     ApplicationDidLaunch,
     ApplicationDidTerminate,
     DeviceDidConnect,

--- a/streamdeck/models/events/__init__.py
+++ b/streamdeck/models/events/__init__.py
@@ -60,7 +60,7 @@ def _get_default_event_names() -> set[str]:
     default_event_names: set[str] = set()
 
     for event_model in DEFAULT_EVENT_MODELS:
-        default_event_names.update(event_model.get_model_event_name())
+        default_event_names.update(event_model.get_model_event_names())
 
     return default_event_names
 

--- a/streamdeck/models/events/__init__.py
+++ b/streamdeck/models/events/__init__.py
@@ -31,7 +31,7 @@ from streamdeck.models.events.visibility import WillAppear, WillDisappear
 if TYPE_CHECKING:
     from typing import Final
 
-    from streamdeck.types import LiteralStrGenericAlias
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 DEFAULT_EVENT_MODELS: Final[list[type[EventBase[LiteralStrGenericAlias]]]] = [

--- a/streamdeck/models/events/adapter.py
+++ b/streamdeck/models/events/adapter.py
@@ -5,18 +5,18 @@ from typing import TYPE_CHECKING, Annotated, Union
 from pydantic import Field, TypeAdapter
 
 from streamdeck.models.events import DEFAULT_EVENT_MODELS
+from streamdeck.types import LiteralStrGenericAlias
 
 
 if TYPE_CHECKING:
     from streamdeck.models.events.base import EventBase
 
 
-
 class EventAdapter:
     """TypeAdapter-encompassing class for handling and extending available event models."""
     def __init__(self) -> None:
-        self._models: list[type[EventBase]] = []
-        self._type_adapter: TypeAdapter[EventBase] | None = None
+        self._models: list[type[EventBase[LiteralStrGenericAlias]]] = []
+        self._type_adapter: TypeAdapter[EventBase[LiteralStrGenericAlias]] | None = None
 
         self._event_names: set[str] = set()
         """A set of all event names that have been registered with the adapter.
@@ -26,7 +26,7 @@ class EventAdapter:
         for model in DEFAULT_EVENT_MODELS:
             self.add_model(model)
 
-    def add_model(self, model: type[EventBase]) -> None:
+    def add_model(self, model: type[EventBase[LiteralStrGenericAlias]]) -> None:
         """Add a model to the adapter, and add the event name of the model to the set of registered event names."""
         self._models.append(model)
         # Models can have multiple event names defined in the Literal args of the event field,
@@ -38,7 +38,7 @@ class EventAdapter:
         return event_name in self._event_names
 
     @property
-    def type_adapter(self) -> TypeAdapter[EventBase]:
+    def type_adapter(self) -> TypeAdapter[EventBase[LiteralStrGenericAlias]]:
         """Get the TypeAdapter instance for the event models."""
         if self._type_adapter is None:
             self._type_adapter = TypeAdapter(
@@ -50,7 +50,7 @@ class EventAdapter:
 
         return self._type_adapter
 
-    def validate_json(self, data: str | bytes) -> EventBase:
+    def validate_json(self, data: str | bytes) -> EventBase[LiteralStrGenericAlias]:
         """Validate a JSON string or bytes object as an event model."""
         return self.type_adapter.validate_json(data)
 

--- a/streamdeck/models/events/adapter.py
+++ b/streamdeck/models/events/adapter.py
@@ -29,7 +29,9 @@ class EventAdapter:
     def add_model(self, model: type[EventBase]) -> None:
         """Add a model to the adapter, and add the event name of the model to the set of registered event names."""
         self._models.append(model)
-        self._event_names.update(model.get_model_event_name())
+        # Models can have multiple event names defined in the Literal args of the event field,
+        # so `get_model_event_names()` returns a tuple of all event names, even if there is only one.
+        self._event_names.update(model.get_model_event_names())
 
     def event_name_exists(self, event_name: str) -> bool:
         """Check if an event name has been registered with the adapter."""

--- a/streamdeck/models/events/adapter.py
+++ b/streamdeck/models/events/adapter.py
@@ -5,11 +5,10 @@ from typing import TYPE_CHECKING, Annotated, Union
 from pydantic import Field, TypeAdapter
 
 from streamdeck.models.events import DEFAULT_EVENT_MODELS
-from streamdeck.types import LiteralStrGenericAlias
 
 
 if TYPE_CHECKING:
-    from streamdeck.models.events.base import EventBase
+    from streamdeck.models.events.base import EventBase, LiteralStrGenericAlias
 
 
 class EventAdapter:

--- a/streamdeck/models/events/application.py
+++ b/streamdeck/models/events/application.py
@@ -11,15 +11,13 @@ class ApplicationPayload(ConfiguredBaseModel):
     """Name of the application that triggered the event."""
 
 
-class ApplicationDidLaunch(EventBase):
+class ApplicationDidLaunch(EventBase[Literal["applicationDidLaunch"]]):
     """Occurs when a monitored application is launched."""
-    event: Literal["applicationDidLaunch"]  # type: ignore[override]
     payload: ApplicationPayload
     """Payload containing the name of the application that triggered the event."""
 
 
-class ApplicationDidTerminate(EventBase):
+class ApplicationDidTerminate(EventBase[Literal["applicationDidTerminate"]]):
     """Occurs when a monitored application terminates."""
-    event: Literal["applicationDidTerminate"]  # type: ignore[override]
     payload: ApplicationPayload
     """Payload containing the name of the application that triggered the event."""

--- a/streamdeck/models/events/deep_link.py
+++ b/streamdeck/models/events/deep_link.py
@@ -9,13 +9,12 @@ class DeepLinkPayload(ConfiguredBaseModel):
     """The deep-link URL, with the prefix omitted."""
 
 
-class DidReceiveDeepLink(EventBase):
+class DidReceiveDeepLink(EventBase[Literal["didReceiveDeepLink"]]):
     """Occurs when Stream Deck receives a deep-link message intended for the plugin.
 
     The message is re-routed to the plugin, and provided as part of the payload.
     One-way deep-link message can be routed to the plugin using the URL format:
     streamdeck://plugins/message/<PLUGIN_UUID>/{MESSAGE}.
     """
-    event: Literal["didReceiveDeepLink"]  # type: ignore[override]
     payload: DeepLinkPayload
     """Payload containing information about the URL that triggered the event."""

--- a/streamdeck/models/events/devices.py
+++ b/streamdeck/models/events/devices.py
@@ -78,13 +78,11 @@ class DeviceInfo(ConfiguredBaseModel):
         return f"DeviceInfo(name={self.name}, type={self.type}, size={self.size})"
 
 
-class DeviceDidConnect(EventBase, DeviceSpecificEventMixin):
+class DeviceDidConnect(EventBase[Literal["deviceDidConnect"]], DeviceSpecificEventMixin):
     """Occurs when a Stream Deck device is connected."""
-    event: Literal["deviceDidConnect"]  # type: ignore[override]
     device_info: Annotated[DeviceInfo, Field(alias="deviceInfo")]
     """Information about the newly connected device."""
 
 
-class DeviceDidDisconnect(EventBase, DeviceSpecificEventMixin):
+class DeviceDidDisconnect(EventBase[Literal["deviceDidDisconnect"]], DeviceSpecificEventMixin):
     """Occurs when a Stream Deck device is disconnected."""
-    event: Literal["deviceDidDisconnect"]  # type: ignore[override]

--- a/streamdeck/models/events/dials.py
+++ b/streamdeck/models/events/dials.py
@@ -28,22 +28,19 @@ class DialRotatePayload(EncoderPayload):
 
 ## Event models for DialDown, DialRotate, and DialUp events
 
-class DialDown(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class DialDown(EventBase[Literal["dialDown"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user presses a dial (Stream Deck +)."""
-    event: Literal["dialDown"]  # type: ignore[override]
     payload: EncoderPayload
     """Contextualized information for this event."""
 
 
-class DialRotate(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class DialRotate(EventBase[Literal["dialRotate"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user rotates a dial (Stream Deck +)."""
-    event: Literal["dialRotate"]  # type: ignore[override]
     payload: DialRotatePayload
     """Contextualized information for this event."""
 
 
-class DialUp(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class DialUp(EventBase[Literal["dialUp"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user releases a pressed dial (Stream Deck +)."""
-    event: Literal["dialUp"]  # type: ignore[override]
     payload: EncoderPayload
     """Contextualized information for this event."""

--- a/streamdeck/models/events/keys.py
+++ b/streamdeck/models/events/keys.py
@@ -48,15 +48,13 @@ class MultiActionKeyGesturePayload(
 
 ## Event models for KeyDown and KeyUp events
 
-class KeyDown(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class KeyDown(EventBase[Literal["keyDown"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user presses a action down."""
-    event: Literal["keyDown"]  # type: ignore[override]
     payload: CardinalityDiscriminated[SingleActionKeyGesturePayload, MultiActionKeyGesturePayload]
     """Contextualized information for this event."""
 
 
-class KeyUp(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class KeyUp(EventBase[Literal["keyUp"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user releases a pressed action."""
-    event: Literal["keyUp"]  # type: ignore[override]
     payload: CardinalityDiscriminated[SingleActionKeyGesturePayload, MultiActionKeyGesturePayload]
     """Contextualized information for this event."""

--- a/streamdeck/models/events/property_inspector.py
+++ b/streamdeck/models/events/property_inspector.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from streamdeck.models.events.base import EventBase
+from streamdeck.models.events.base import (
+    EventBase,
+)
 from streamdeck.models.events.common import (
     ContextualEventMixin,
     DeviceSpecificEventMixin,
@@ -10,24 +12,21 @@ from streamdeck.models.events.common import (
 )
 
 
-class DidReceivePropertyInspectorMessage(EventBase, ContextualEventMixin):
+class DidReceivePropertyInspectorMessage(EventBase[Literal["sendToPlugin"]], ContextualEventMixin):
     """Occurs when a message was received from the UI."""
-    event: Literal["sendToPlugin"]  # type: ignore[override]
     payload: PluginDefinedData
     """The data payload received from the UI."""
 
 
-class PropertyInspectorDidAppear(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class PropertyInspectorDidAppear(EventBase[Literal["propertyInspectorDidAppear"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the property inspector associated with the action becomes visible.
 
     I.e. the user selected an action in the Stream Deck application.
     """
-    event: Literal["propertyInspectorDidAppear"]  # type: ignore[override]
 
 
-class PropertyInspectorDidDisappear(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class PropertyInspectorDidDisappear(EventBase[Literal["propertyInspectorDidDisappear"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the property inspector associated with the action becomes invisible.
 
     I.e. the user unselected the action in the Stream Deck application.
     """
-    event: Literal["propertyInspectorDidDisappear"]  # type: ignore[override]

--- a/streamdeck/models/events/settings.py
+++ b/streamdeck/models/events/settings.py
@@ -40,9 +40,8 @@ class MultiActionSettingsPayload(
     """
 
 
-class DidReceiveSettings(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class DidReceiveSettings(EventBase[Literal["didReceiveSettings"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the settings associated with an action instance are requested, or when the the settings were updated by the property inspector."""
-    event: Literal["didReceiveSettings"]  # type: ignore[override]
     payload: CardinalityDiscriminated[SingleActionSettingsPayload, MultiActionSettingsPayload]
     """Contextualized information for this event."""
 
@@ -55,8 +54,7 @@ class GlobalSettingsPayload(ConfiguredBaseModel):
     """The global settings received from the Stream Deck."""
 
 
-class DidReceiveGlobalSettings(EventBase):
+class DidReceiveGlobalSettings(EventBase[Literal["didReceiveGlobalSettings"]]):
     """Occurs when the plugin receives the global settings from the Stream Deck."""
-    event: Literal["didReceiveGlobalSettings"]  # type: ignore[override]
     payload: GlobalSettingsPayload
     """Additional information about the event that occurred."""

--- a/streamdeck/models/events/system.py
+++ b/streamdeck/models/events/system.py
@@ -5,6 +5,5 @@ from typing import Literal
 from streamdeck.models.events.base import EventBase
 
 
-class SystemDidWakeUp(EventBase):
+class SystemDidWakeUp(EventBase[Literal["systemDidWakeUp"]]):
     """Occurs when the computer wakes up."""
-    event: Literal["systemDidWakeUp"]  # type: ignore[override]

--- a/streamdeck/models/events/title_parameters.py
+++ b/streamdeck/models/events/title_parameters.py
@@ -47,9 +47,8 @@ class TitleParametersDidChangePayload(
     """Defines aesthetic properties that determine how the title should be rendered."""
 
 
-class TitleParametersDidChange(EventBase, DeviceSpecificEventMixin):
+class TitleParametersDidChange(EventBase[Literal["titleParametersDidChange"]], DeviceSpecificEventMixin):
     """Occurs when the user updates an action's title settings in the Stream Deck application."""
-    event: Literal["titleParametersDidChange"]  # type: ignore[override]
     context: str
     """Identifies the instance of an action that caused the event, i.e. the specific key or dial."""
     payload: TitleParametersDidChangePayload

--- a/streamdeck/models/events/touch_tap.py
+++ b/streamdeck/models/events/touch_tap.py
@@ -22,8 +22,7 @@ class TouchTapPayload(BasePayload[EncoderControllerType], CoordinatesPayloadMixi
     """Coordinates of where the touchscreen tap occurred, relative to the canvas of the action."""
 
 
-class TouchTap(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class TouchTap(EventBase[Literal["touchTap"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when the user taps the touchscreen (Stream Deck +)."""
-    event: Literal["touchTap"]  # type: ignore[override]
     payload: TouchTapPayload
     """Contextualized information for this event."""

--- a/streamdeck/models/events/visibility.py
+++ b/streamdeck/models/events/visibility.py
@@ -35,20 +35,18 @@ class MultiActionVisibilityPayload(
 
 ## Event models for WillAppear and WillDisappear events
 
-class WillAppear(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class WillAppear(EventBase[Literal["willAppear"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when an action appears on the Stream Deck due to the user navigating to another page, profile, folder, etc.
 
     This also occurs during startup if the action is on the "front page".
     An action refers to all types of actions, e.g. keys, dials, touchscreens, pedals, etc.
     """
-    event: Literal["willAppear"]  # type: ignore[override]
     payload: CardinalityDiscriminated[SingleActionVisibilityPayload, MultiActionVisibilityPayload]
 
 
-class WillDisappear(EventBase, ContextualEventMixin, DeviceSpecificEventMixin):
+class WillDisappear(EventBase[Literal["willDisappear"]], ContextualEventMixin, DeviceSpecificEventMixin):
     """Occurs when an action disappears from the Stream Deck due to the user navigating to another page, profile, folder, etc.
 
     An action refers to all types of actions, e.g. keys, dials, touchscreens, pedals, etc.
     """
-    event: Literal["willDisappear"]  # type: ignore[override]
     payload: CardinalityDiscriminated[SingleActionVisibilityPayload, MultiActionVisibilityPayload]

--- a/streamdeck/types.py
+++ b/streamdeck/types.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Protocol, TypeVar, Union
 
-from typing_extensions import LiteralString  # noqa: UP035
-
-from streamdeck.models.events import DEFAULT_EVENT_NAMES, EventBase
+from streamdeck.models.events import EventBase
 
 
 if TYPE_CHECKING:
@@ -20,12 +18,6 @@ EventNameStr: TypeAlias = str  # noqa: UP040
 
 We don't define literal string values here, as the list of available event names can be added to dynamically.
 """
-
-
-# This type alias is used to handle static type checking accurately while still conveying that
-# a value is expected to be a Literal with string type args.
-LiteralStrGenericAlias: TypeAlias = LiteralString  # noqa: UP040
-"""Type alias for a generic literal string type."""
 
 
 ### Event Handler Type Definitions ###

--- a/streamdeck/types.py
+++ b/streamdeck/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import inspect
 from typing import TYPE_CHECKING, Protocol, TypeVar, Union
 
+from typing_extensions import LiteralString  # noqa: UP035
+
 from streamdeck.models.events import DEFAULT_EVENT_NAMES, EventBase
 
 
@@ -20,9 +22,10 @@ We don't define literal string values here, as the list of available event names
 """
 
 
-def is_valid_event_name(event_name: str) -> TypeIs[EventNameStr]:
-    """Check if the event name is one of the available event names."""
-    return event_name in DEFAULT_EVENT_NAMES
+# This type alias is used to handle static type checking accurately while still conveying that
+# a value is expected to be a Literal with string type args.
+LiteralStrGenericAlias: TypeAlias = LiteralString  # noqa: UP040
+"""Type alias for a generic literal string type."""
 
 
 ### Event Handler Type Definitions ###

--- a/tests/actions/test_action_event_handler_filtering.py
+++ b/tests/actions/test_action_event_handler_filtering.py
@@ -6,7 +6,6 @@ from unittest.mock import create_autospec
 import pytest
 from streamdeck.actions import Action, ActionRegistry, GlobalAction
 from streamdeck.models.events.common import ContextualEventMixin
-from streamdeck.types import LiteralStrGenericAlias
 
 from tests.test_utils.fake_event_factories import (
     ApplicationDidLaunchEventFactory,
@@ -20,6 +19,7 @@ if TYPE_CHECKING:
 
     from polyfactory.factories.pydantic_factory import ModelFactory
     from streamdeck.models import events
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 

--- a/tests/actions/test_action_event_handler_filtering.py
+++ b/tests/actions/test_action_event_handler_filtering.py
@@ -6,6 +6,7 @@ from unittest.mock import create_autospec
 import pytest
 from streamdeck.actions import Action, ActionRegistry, GlobalAction
 from streamdeck.models.events.common import ContextualEventMixin
+from streamdeck.types import LiteralStrGenericAlias
 
 from tests.test_utils.fake_event_factories import (
     ApplicationDidLaunchEventFactory,
@@ -35,14 +36,14 @@ def mock_event_handler() -> Mock:
     DeviceDidConnectFactory,
     ApplicationDidLaunchEventFactory
 ])
-def fake_event_data(request: pytest.FixtureRequest) -> events.EventBase:
-    event_factory = cast("ModelFactory[events.EventBase]", request.param)
+def fake_event_data(request: pytest.FixtureRequest) -> events.EventBase[LiteralStrGenericAlias]:
+    event_factory = cast("ModelFactory[events.EventBase[LiteralStrGenericAlias]]", request.param)
     return event_factory.build()
 
 
 def test_global_action_gets_triggered_by_event(
     mock_event_handler: Mock,
-    fake_event_data: events.EventBase,
+    fake_event_data: events.EventBase[LiteralStrGenericAlias],
 ) -> None:
     """Test that a global action's event handlers are triggered by an event.
 
@@ -62,7 +63,7 @@ def test_global_action_gets_triggered_by_event(
 
 def test_action_gets_triggered_by_event(
     mock_event_handler: Mock,
-    fake_event_data: events.EventBase,
+    fake_event_data: events.EventBase[LiteralStrGenericAlias],
 ) -> None:
     """Test that an action's event handlers are triggered by an event.
 
@@ -89,7 +90,7 @@ def test_action_gets_triggered_by_event(
 
 def test_global_action_registry_get_action_handlers_filtering(
     mock_event_handler: Mock,
-    fake_event_data: events.EventBase,
+    fake_event_data: events.EventBase[LiteralStrGenericAlias],
 ) -> None:
     # Extract the action UUID from the fake event data, or use a default value
     action_uuid: str | None = fake_event_data.action if isinstance(fake_event_data, ContextualEventMixin) else None
@@ -116,7 +117,7 @@ def test_global_action_registry_get_action_handlers_filtering(
 
 def test_action_registry_get_action_handlers_filtering(
     mock_event_handler: Mock,
-    fake_event_data: events.EventBase,
+    fake_event_data: events.EventBase[LiteralStrGenericAlias],
 ) -> None:
     # Extract the action UUID from the fake event data, or use a default value
     action_uuid: str | None = fake_event_data.action if isinstance(fake_event_data, ContextualEventMixin) else None
@@ -150,12 +151,12 @@ def test_multiple_actions_filtering() -> None:
     action_event_handler_called = False
 
     @global_action.on("applicationDidLaunch")
-    def _global_app_did_launch_action_handler(event: events.EventBase) -> None:
+    def _global_app_did_launch_action_handler(event: events.EventBase[LiteralStrGenericAlias]) -> None:
         nonlocal global_action_event_handler_called
         global_action_event_handler_called = True
 
     @action.on("keyDown")
-    def _action_key_down_event_handler(event: events.EventBase) -> None:
+    def _action_key_down_event_handler(event: events.EventBase[LiteralStrGenericAlias]) -> None:
         nonlocal action_event_handler_called
         action_event_handler_called = True
 

--- a/tests/actions/test_action_registry.py
+++ b/tests/actions/test_action_registry.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from streamdeck.actions import Action, ActionRegistry
+from streamdeck.types import LiteralStrGenericAlias
 
 from tests.test_utils.fake_event_factories import (
     DialDownEventFactory,
@@ -46,7 +47,7 @@ def test_get_action_handlers_with_handlers() -> None:
     action = Action("my-fake-action-uuid")
 
     @action.on("dialDown")
-    def dial_down_handler(event: events.EventBase) -> None:
+    def dial_down_handler(event_data: events.EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     registry.register(action)
@@ -66,11 +67,11 @@ def test_get_action_handlers_multiple_actions() -> None:
     action2 = Action("fake-action-uuid-2")
 
     @action1.on("keyUp")
-    def key_up_handler1(event) -> None:
+    def key_up_handler1(event_data: events.EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     @action2.on("keyUp")
-    def key_up_handler2(event) -> None:
+    def key_up_handler2(event_data: events.EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     registry.register(action1)

--- a/tests/actions/test_action_registry.py
+++ b/tests/actions/test_action_registry.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 from streamdeck.actions import Action, ActionRegistry
-from streamdeck.types import LiteralStrGenericAlias
 
 from tests.test_utils.fake_event_factories import (
     DialDownEventFactory,
@@ -15,6 +14,7 @@ from tests.test_utils.fake_event_factories import (
 
 if TYPE_CHECKING:
     from streamdeck.models import events
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 def test_register_action() -> None:

--- a/tests/actions/test_actions.py
+++ b/tests/actions/test_actions.py
@@ -5,13 +5,14 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from streamdeck.actions import Action, ActionBase, GlobalAction
 from streamdeck.models.events import DEFAULT_EVENT_NAMES
+from streamdeck.types import LiteralStrGenericAlias
 
 
 if TYPE_CHECKING:
     from streamdeck.models.events import EventBase
 
 
-@pytest.fixture(params=[[Action, ("test.uuid.for.action",)], [GlobalAction, []]])
+@pytest.fixture(params=[[Action, ("test.uuid.for.action",)], [GlobalAction, ()]])
 def action(request: pytest.FixtureRequest) -> ActionBase:
     """Fixture for initializing the Action and GlobalAction classes to parameterize the tests.
 
@@ -25,7 +26,7 @@ def action(request: pytest.FixtureRequest) -> ActionBase:
 def test_action_register_event_handler(action: ActionBase, event_name: str) -> None:
     """Test that an event handler can be registered for each valid event name."""
     @action.on(event_name)
-    def handler(event: EventBase) -> None:
+    def handler(event_data: EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     # Ensure the handler is registered for the correct event name
@@ -37,10 +38,10 @@ def test_action_get_event_handlers(action: ActionBase) -> None:
     """Test that the correct event handlers are retrieved for each event name."""
     # Each iteration will add to the action's event handlers, thus we're checking that
     # even with multiple event names, the handlers are correctly retrieved.
-    for i, event_name in enumerate(DEFAULT_EVENT_NAMES):
+    for _, event_name in enumerate(DEFAULT_EVENT_NAMES):
         # Register a handler for the given event name
         @action.on(event_name)
-        def handler(event: EventBase) -> None:
+        def handler(event_data: EventBase[LiteralStrGenericAlias]) -> None:
             pass
 
         # Retrieve the handlers using the generator
@@ -73,11 +74,11 @@ def test_action_get_event_handlers_invalid_event_name(action: ActionBase) -> Non
 def test_action_register_multiple_handlers_for_event(action: ActionBase) -> None:
     """Test that multiple handlers can be registered for the same event on the same action."""
     @action.on("keyDown")
-    def handler_one(event: EventBase) -> None:
+    def handler_one(event_data: EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     @action.on("keyDown")
-    def handler_two(event: EventBase) -> None:
+    def handler_two(event_data: EventBase[LiteralStrGenericAlias]) -> None:
         pass
 
     handlers = list(action.get_event_handlers("keyDown"))

--- a/tests/actions/test_actions.py
+++ b/tests/actions/test_actions.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 from streamdeck.actions import Action, ActionBase, GlobalAction
 from streamdeck.models.events import DEFAULT_EVENT_NAMES
-from streamdeck.types import LiteralStrGenericAlias
 
 
 if TYPE_CHECKING:
     from streamdeck.models.events import EventBase
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 @pytest.fixture(params=[[Action, ("test.uuid.for.action",)], [GlobalAction, ()]])

--- a/tests/event_listener/test_event_listener.py
+++ b/tests/event_listener/test_event_listener.py
@@ -7,11 +7,12 @@ from unittest.mock import Mock, patch
 import pytest
 from streamdeck.event_listener import EventListener, EventListenerManager
 from streamdeck.models.events import ApplicationDidLaunch, EventBase
+from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 class MockEventListener(EventListener):
     """Mock implementation of EventListener for testing."""
-    event_models: ClassVar[list[type[EventBase]]] = [ApplicationDidLaunch]
+    event_models: ClassVar[list[type[EventBase[LiteralStrGenericAlias]]]] = [ApplicationDidLaunch]
 
     def __init__(self):
         self._running = True
@@ -33,7 +34,7 @@ class MockEventListener(EventListener):
 
 class SlowMockEventListener(EventListener):
     """Mock implementation of EventListener that yields events with a delay."""
-    event_models: ClassVar[list[type[EventBase]]] = [ApplicationDidLaunch]
+    event_models: ClassVar[list[type[EventBase[LiteralStrGenericAlias]]]] = [ApplicationDidLaunch]
 
     def __init__(self, delay: float = 0.1):
         self._running = True
@@ -53,7 +54,7 @@ class SlowMockEventListener(EventListener):
 
 class ExceptionEventListener(EventListener):
     """Mock implementation of EventListener that raises an exception."""
-    event_models: ClassVar[list[type[EventBase]]] = [ApplicationDidLaunch]
+    event_models: ClassVar[list[type[EventBase[LiteralStrGenericAlias]]]] = [ApplicationDidLaunch]
 
     def listen(self) -> Generator[str, None, None]:
         self._running = True
@@ -91,9 +92,9 @@ def test_event_stream_basic():
     manager.add_listener(listener)
 
     # Collect the first few events
-    events = []
+    events : list[EventNameStr] = []
     for event in manager.event_stream():
-        events.append(event)
+        events.append(event)  # type: ignore[arg-type]
         if len(events) >= 3:  # We expect 3 events from MockEventListener
             manager.stop()
             break
@@ -112,9 +113,9 @@ def test_event_stream_multiple_listeners():
     manager.add_listener(listener2)
 
     # Collect all events
-    events = []
+    events: list[EventNameStr] = []
     for event in manager.event_stream():
-        events.append(event)
+        events.append(event)  # type: ignore[arg-type]
         if len(events) >= 6:  # We expect 6 events total (3 from each listener)
             manager.stop()
             break

--- a/tests/plugin_manager/conftest.py
+++ b/tests/plugin_manager/conftest.py
@@ -14,6 +14,7 @@ from tests.test_utils.fake_event_factories import KeyDownEventFactory
 if TYPE_CHECKING:
     import pytest_mock
     from streamdeck.models import events
+    from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 @pytest.fixture
@@ -103,7 +104,7 @@ def mock_event_listener_manager_with_fake_events(patch_event_listener_manager: M
     """
     print("MOCK EVENT LISTENER MANAGER")
     # Create a list of fake event messages, and convert them to json strings to be passed back by the client.listen() method.
-    fake_event_messages: list[events.EventBase] = [
+    fake_event_messages: list[events.EventBase[LiteralStrGenericAlias]] = [
         KeyDownEventFactory.build(action="my-fake-action-uuid"),
     ]
 

--- a/tests/plugin_manager/test_plugin_manager.py
+++ b/tests/plugin_manager/test_plugin_manager.py
@@ -10,6 +10,7 @@ from streamdeck.models.events import (  #, event_adapter
     DEFAULT_EVENT_NAMES,
     EventBase,
 )
+from streamdeck.models.events.base import LiteralStrGenericAlias
 
 
 @pytest.fixture
@@ -115,7 +116,7 @@ def test_plugin_manager_adds_websocket_event_listener(
 @pytest.mark.integration
 @pytest.mark.usefixtures("patch_websocket_client")
 def test_plugin_manager_process_event(
-    mock_event_listener_manager_with_fake_events: tuple[Mock, list[EventBase]],
+    mock_event_listener_manager_with_fake_events: tuple[Mock, list[EventBase[LiteralStrGenericAlias]]],
     _spy_action_registry_get_action_handlers: None,  # This fixture must come after mock_event_listener_manager_with_fake_events to ensure monkeypatching occurs.
     _spy_event_adapter_validate_json: None,  # This fixture must come after mock_event_listener_manager_with_fake_events to ensure monkeypatching occurs.
     plugin_manager: PluginManager,   # This fixture must come after patch_event_listener_manager and spy-fixtures to ensure things are mocked and spied correctly.

--- a/tests/plugin_manager/test_plugin_manager.py
+++ b/tests/plugin_manager/test_plugin_manager.py
@@ -54,7 +54,7 @@ def test_plugin_manager_register_action(plugin_manager: PluginManager) -> None:
 
 def test_plugin_manager_register_event_listener(plugin_manager: PluginManager) -> None:
     """Test that an event listener can be registered in the PluginManager."""
-    mock_event_model_class = Mock(get_model_event_name=lambda: ["fake_event_name"])
+    mock_event_model_class = Mock(get_model_event_names=lambda: ["fake_event_name"])
     listener = Mock(event_models=[mock_event_model_class])
 
     assert len(plugin_manager._event_listener_manager.listeners_lookup_by_thread) == 0


### PR DESCRIPTION
Refactored Event model classes to use genericized parameters for setting the string literal alias of the `event` field. Note that the literal type can still be defined explicitly at the field as well—static typing & Pydantic will still work as expected.